### PR TITLE
fix: 挂起托盘 WebView2 并缓存状态探测，降低后台 CPU 占用（~2% → ~0.2%）

### DIFF
--- a/src-tauri/src/audio/pcm_router.rs
+++ b/src-tauri/src/audio/pcm_router.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub const DEFAULT_PCM_PORT: u16 = 31680;
 
@@ -442,4 +442,20 @@ pub fn audio_router_ready() -> bool {
         Ok((n, _)) => &buf[..n] == b"PONG",
         Err(_) => false,
     }
+}
+
+/// 带缓存的就绪探测：每次调用都新建 socket + PING 往返，前端状态页每秒问一次。
+/// 冲突检测/重启桥接等需要新鲜结果的路径请用无缓存的 `audio_router_ready()`。
+pub fn audio_router_ready_cached() -> bool {
+    // ponytail: TTL 5s；router 挂掉后状态页最多延迟 5s 变红
+    static CACHE: std::sync::Mutex<Option<(Instant, bool)>> = std::sync::Mutex::new(None);
+    let mut g = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some((at, ok)) = *g {
+        if at.elapsed() < Duration::from_secs(5) {
+            return ok;
+        }
+    }
+    let ok = audio_router_ready();
+    *g = Some((Instant::now(), ok));
+    ok
 }

--- a/src-tauri/src/audio/vb_cable.rs
+++ b/src-tauri/src/audio/vb_cable.rs
@@ -96,6 +96,12 @@ fn asset_candidates(file_name: &str) -> Vec<PathBuf> {
 }
 
 pub fn find_driver_zip() -> Option<PathBuf> {
+    // ponytail: 资产安装后不变，但每次哈希几十 MB 的 zip；只算一次
+    static ZIP: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+    ZIP.get_or_init(|| find_driver_zip_uncached()).clone()
+}
+
+fn find_driver_zip_uncached() -> Option<PathBuf> {
     for path in asset_candidates(DRIVER_ZIP_NAME) {
         if !path.is_file() {
             continue;
@@ -150,8 +156,7 @@ fn probe_cable_endpoints() -> (bool, bool) {
     (false, false)
 }
 
-pub fn voice_env_status() -> VoiceEnvStatus {
-    let (cable_input, cable_output) = probe_cable_endpoints();
+fn build_voice_env_status(cable_input: bool, cable_output: bool) -> VoiceEnvStatus {
     let ready = cable_input && cable_output;
     let zip = find_driver_zip();
     let embedded_available = zip.is_some() && find_configure_script().is_some();
@@ -172,6 +177,32 @@ pub fn voice_env_status() -> VoiceEnvStatus {
         download_zip_url: DOWNLOAD_ZIP_URL.into(),
         message,
     }
+}
+
+pub fn voice_env_status() -> VoiceEnvStatus {
+    let (cable_input, cable_output) = probe_cable_endpoints();
+    build_voice_env_status(cable_input, cable_output)
+}
+
+/// 带缓存的探测：cpal 全量枚举音频设备走 COM/RPC，前端状态页每秒轮询一次，
+/// 不缓存时实测占 ~3-4% 单核。修复/安装流程请用无缓存的 `voice_env_status()`。
+pub fn voice_env_status_cached() -> VoiceEnvStatus {
+    // ponytail: TTL 30s，声卡安装后状态页最多延迟 30s 变绿（修复按钮走无缓存路径）
+    static CACHE: std::sync::Mutex<Option<(std::time::Instant, (bool, bool))>> =
+        std::sync::Mutex::new(None);
+    fn probe_cached() -> (bool, bool) {
+        let mut g = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((at, r)) = *g {
+            if at.elapsed() < std::time::Duration::from_secs(30) {
+                return r;
+            }
+        }
+        let r = probe_cable_endpoints();
+        *g = Some((std::time::Instant::now(), r));
+        r
+    }
+    let (cable_input, cable_output) = probe_cached();
+    build_voice_env_status(cable_input, cable_output)
 }
 
 fn desktop_report_path() -> PathBuf {

--- a/src-tauri/src/bridges/xiaomi/key_log.rs
+++ b/src-tauri/src/bridges/xiaomi/key_log.rs
@@ -363,7 +363,12 @@ fn windows_vk_poll_logger(
             }
             prev.insert(vk, down);
         }
-        std::thread::sleep(Duration::from_millis(25));
+        // ponytail: 25ms 高频仅 Alt+Tab 长按期间需要；平时 150ms 省唤醒
+        std::thread::sleep(Duration::from_millis(if crate::bridges::xiaomi::key_mapping::alt_tab_hold_active() {
+            25
+        } else {
+            150
+        }));
     }
 }
 

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -414,9 +414,9 @@ pub fn xiaomi_host_status_now(app: &AppHandle) -> XiaomiHostStatus {
         .try_state::<Arc<XiaomiRuntime>>()
         .map(|r| r.running.load(std::sync::atomic::Ordering::SeqCst))
         .unwrap_or(false);
-    let audio_alive = crate::audio::pcm_router::audio_router_ready()
+    let audio_alive = crate::audio::pcm_router::audio_router_ready_cached()
         || crate::audio::pcm_router::audio_router_process_alive();
-    let cable_ready = crate::audio::vb_cable::voice_env_status().ready;
+    let cable_ready = crate::audio::vb_cable::voice_env_status_cached().ready;
     let atvv_ok = crate::bridges::xiaomi::connect::atvv_subscribed();
 
     let items = vec![

--- a/src-tauri/src/ipc/tray.rs
+++ b/src-tauri/src/ipc/tray.rs
@@ -13,6 +13,7 @@ fn restore_main_window(app: &AppHandle) {
         let _ = window.show();
         let _ = window.set_focus();
     }
+    crate::set_main_webview_visible(app, true);
 }
 
 fn quit_app(app: &AppHandle) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,20 @@ fn focus_main_window(app: &tauri::AppHandle) {
         let _ = window.show();
         let _ = window.set_focus();
     }
+    set_main_webview_visible(app, true);
+}
+
+/// 托盘隐藏时挂起 WebView2 渲染：不调 SetIsVisible(false) 时 Chromium 会继续
+/// 全速合成动画并保持 1s 轮询定时器不节流（实测占 ~5.6% 单核）
+pub fn set_main_webview_visible(app: &tauri::AppHandle, visible: bool) {
+    #[cfg(target_os = "windows")]
+    if let Some(wv) = app.get_webview_window("main") {
+        let _ = wv.with_webview(move |platform| unsafe {
+            let _ = platform.controller().SetIsVisible(visible);
+        });
+    }
+    #[cfg(not(target_os = "windows"))]
+    let _ = (app, visible);
 }
 
 #[cfg_attr(mobile, mobile_entry_point)]
@@ -128,6 +142,7 @@ pub fn run() {
                         if minimize {
                             api.prevent_close();
                             let _ = window_.hide();
+                            set_main_webview_visible(&app_handle, false);
                         }
                         // else: 允许关闭 → 触发 Exit → cleanup_on_exit
                     }


### PR DESCRIPTION
## 问题

托盘后台运行时（窗口已隐藏、遥控器正常连接），任务管理器中主进程持续 0.5~1.2% CPU，WebView2 进程组另有 ~1%，合计约 2% 且不回落。

## 根因（v0.2.4 release 实测）

20s 采样、确认窗口已隐藏（IsWindowVisible=False）：

| 进程 | CPU（占单核） |
|---|---|
| nexus-prime.exe（主进程） | 4.8% |
| msedgewebview2 gpu / renderer / browser | 2.5% / 2.3% / 0.8% |
| nexus-prime.exe（audio_router 子进程） | 0%（干净） |

1. **窗口隐藏后 WebView2 未挂起**：`window.hide()` 只隐藏 Win32 窗口，未调用 `ICoreWebView2Controller::SetIsVisible(false)`。Chromium 认为页面仍可见，持续合成 CSS 无限动画（pulse/充电流光），`setInterval` 定时器不节流。
2. **每秒状态轮询触发昂贵后端调用**：因 1 未节流，前端 `setInterval(refreshHost, 1000)` 在托盘照常执行 → `probe_cable_endpoints()` 用 cpal 全量枚举音频设备（COM/RPC，线程采样可见热点在多个线程池线程轮换、等待 LpcReply）+ `audio_router_ready()` 每次新建 UDP socket PING。

已排除：audio_router 子进程（0%）、日志写入（实测 ~75 B/s）、键盘钩子（GetMessageW 阻塞式）、忙等死循环。

## 修改

1. **隐藏时挂起 WebView2**（`lib.rs`、`tray.rs`）：CloseRequested 隐藏时 `SetIsVisible(false)`；三条恢复路径（托盘左键/打开状态菜单/按键与语音设置菜单、单实例二次启动）`SetIsVisible(true)`。Chromium 随之停止渲染并把后台定时器节流到 1 次/分钟
2. **状态探测缓存**（`vb_cable.rs`、`pcm_router.rs`、`commands.rs`）：新增 `voice_env_status_cached()`（TTL 30s）与 `audio_router_ready_cached()`（TTL 5s），仅用于每秒状态轮询；修复/冲突检测等需要新鲜结果的路径保持无缓存。`find_driver_zip` 的 zip 哈希只计算一次（静态资产）
3. **vk-poll 自适应间隔**（`key_log.rs`）：仅 Alt+Tab 长按会话期间保持 25ms 轮询，平时 150ms（转发行为无差异）

## 预期效果

托盘 20s 采样：主进程 953ms → <400ms；WebView2 进程 1109ms → ≈0。整机占用约 2% → <0.3%。

## 验证状态

- 测试机无 Rust 工具链，**尚未本地编译**，需要 CI 或本地 `cargo check` + `cargo test` + `tauri build` 验证
- 需手工回归三条窗口恢复路径（托盘左键、托盘菜单、二次启动激活），确认无白屏